### PR TITLE
Improve workflow and Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.github
+*.md
+assets
+**/*_test.go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,6 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+# This workflow builds and tests the Go project
+# For more information see:
+# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
 
@@ -26,6 +27,10 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: '1.21'
+        cache: true
+
+    - name: Vet
+      run: go vet ./...
 
     - name: Build
       run: go build -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.21-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o shawtyfy ./main.go
+
+FROM gcr.io/distroless/static
+COPY --from=build /src/shawtyfy /shawtyfy
+EXPOSE 9808
+ENTRYPOINT ["/shawtyfy"]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ Run all unit tests with:
 go test ./...
 ```
 
+## Docker
+
+Build the container image:
+```bash
+docker build -t shawtyfy .
+```
+
+Run the container:
+```bash
+docker run --rm -p 9808:9808 shawtyfy
+```
 ## Contributing
 
 Contributions are welcome! Please open an issue or pull request to propose changes or improvements.


### PR DESCRIPTION
## Summary
- cache modules and run `go vet` before build in CI
- multi-stage distroless Docker image
- ignore development files with `.dockerignore`
- document container usage in the README

## Testing
- `go vet ./...`
- `go test ./...` *(fails: Error init redis: dial tcp 127.0.0.1:6379: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_684129e1b1a48332a7b0a44b2993da59